### PR TITLE
Rewrite persistence to use Windows / macOS / Linux native keyrings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,16 @@
 # in Unix via a file share from Windows, the scripts will work.
 *.sh text eol=lf
 
+# .editorconfig declares end_of_line = crlf for the entire tree. Force CRLF in
+# the working copy so cross-platform CI (and Linux/macOS contributors) see the
+# files exactly as editorconfig demands -- otherwise the IDE0055 formatting
+# analyzer (treat-warnings-as-errors) fails the build on non-Windows runners.
+*.cs       text eol=crlf
+*.csproj   text eol=crlf
+*.props    text eol=crlf
+*.targets  text eol=crlf
+*.editorconfig text eol=crlf
+
 ###############################
 # Git Large File System (LFS) #
 ###############################

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -1,0 +1,56 @@
+name: Cross-platform verification
+
+on:
+  push:
+    branches: [main, develop]
+    paths-ignore:
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
+  workflow_dispatch:
+
+concurrency:
+  group: cross-platform-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Build & Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK 10.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install libsecret (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsecret-1-0
+
+      - name: Restore
+        run: dotnet restore CredentialCache.sln
+
+      - name: Build
+        run: dotnet build CredentialCache.sln --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test CredentialCache.Test/CredentialCache.Test.csproj --configuration Release --no-build --logger "console;verbosity=normal"

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -53,4 +53,4 @@ jobs:
         run: dotnet build CredentialCache.sln --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test CredentialCache.Test/CredentialCache.Test.csproj --configuration Release --no-build --logger "console;verbosity=normal"
+        run: dotnet test CredentialCache.Test/CredentialCache.Test.csproj --configuration Release --no-build

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -53,4 +53,4 @@ jobs:
         run: dotnet build CredentialCache.sln --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test CredentialCache.Test/CredentialCache.Test.csproj --configuration Release --no-build
+        run: dotnet test --project CredentialCache.Test/CredentialCache.Test.csproj --configuration Release --no-build

--- a/CredentialCache.Test/CredentialCache.Test.csproj
+++ b/CredentialCache.Test/CredentialCache.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Sdk Name="MSTest.Sdk" />
   <Sdk Name="ktsu.Sdk" />
 
@@ -6,6 +6,10 @@
     <IsTestProject>true</IsTestProject>
     <TargetFramework>net10.0</TargetFramework>
     <TargetFrameworks></TargetFrameworks>
+    <!-- Avoid pulling Microsoft.NETCore.App.Host.{distro-specific}-RID packages
+         that some SDK builds resolve based on the host distro. Tests run via
+         `dotnet test` / `dotnet exec` and don't need an apphost executable. -->
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CredentialCache.Test/CredentialCacheTests.cs
+++ b/CredentialCache.Test/CredentialCacheTests.cs
@@ -4,21 +4,22 @@
 
 namespace ktsu.CredentialCache.Test;
 
+using ktsu.CredentialCache.Storage;
+using ktsu.Semantics.Strings;
+
 [TestClass]
-//[DoNotParallelize]
 public class CredentialCacheTests
 {
+	private static CredentialCache NewCache() => new(new InMemoryCredentialStore());
+
 	[TestMethod]
 	public void TryGetReturnsFalseWhenCredentialNotFound()
 	{
-		// Arrange
-		var cache = CredentialCache.Instance;
-		var guid = CredentialCache.CreatePersonaGUID();
+		using CredentialCache cache = NewCache();
+		PersonaGUID guid = CredentialCache.CreatePersonaGUID();
 
-		// Act
-		var result = cache.TryGet(guid, out var credential);
+		bool result = cache.TryGet(guid, out Credential? credential);
 
-		// Assert
 		Assert.IsFalse(result, "TryGet should return false when credential is not found");
 		Assert.IsNull(credential);
 	}
@@ -26,31 +27,62 @@ public class CredentialCacheTests
 	[TestMethod]
 	public void AddOrReplaceAddsCredentialSuccessfully()
 	{
-		// Arrange
-		var cache = CredentialCache.Instance;
-		var guid = CredentialCache.CreatePersonaGUID();
-		var credential = new CredentialWithNothing();
+		using CredentialCache cache = NewCache();
+		PersonaGUID guid = CredentialCache.CreatePersonaGUID();
+		CredentialWithNothing credential = new();
 
-		// Act
 		cache.AddOrReplace(guid, credential);
-		var result = cache.TryGet(guid, out var retrievedCredential);
+		bool result = cache.TryGet(guid, out Credential? retrievedCredential);
 
-		// Assert
 		Assert.IsTrue(result, "TryGet should return true after adding a credential");
 		Assert.AreEqual(credential, retrievedCredential);
 	}
 
 	[TestMethod]
+	public void AddOrReplacePersistsCredentialToBackingStore()
+	{
+		InMemoryCredentialStore store = new();
+		PersonaGUID guid = CredentialCache.CreatePersonaGUID();
+		CredentialWithUsernamePassword credential = new()
+		{
+			Username = SemanticString<CredentialUsername>.Create("alice"),
+			Password = SemanticString<CredentialPassword>.Create("hunter2"),
+		};
+
+		using (CredentialCache writer = new(store))
+		{
+			writer.AddOrReplace(guid, credential);
+		}
+
+		using CredentialCache reader = new(store);
+		Assert.IsTrue(reader.TryGet(guid, out Credential? roundTripped));
+		CredentialWithUsernamePassword? typed = roundTripped as CredentialWithUsernamePassword;
+		Assert.IsNotNull(typed);
+		Assert.AreEqual("alice", typed!.Username.ToString());
+		Assert.AreEqual("hunter2", typed.Password.ToString());
+	}
+
+	[TestMethod]
+	public void RemoveDeletesCredentialFromBothLayers()
+	{
+		InMemoryCredentialStore store = new();
+		PersonaGUID guid = CredentialCache.CreatePersonaGUID();
+		CredentialWithNothing credential = new();
+
+		using CredentialCache cache = new(store);
+		cache.AddOrReplace(guid, credential);
+		Assert.IsTrue(cache.Remove(guid));
+		Assert.IsFalse(cache.TryGet(guid, out _));
+		Assert.IsFalse(store.TryLoad(guid, out _));
+	}
+
+	[TestMethod]
 	public void TryCreateReturnsFalseWhenFactoryNotRegistered()
 	{
-		// Arrange
-		var cache = CredentialCache.Instance;
-		cache.UnregisterCredentialFactory<CredentialWithNothing>(); //ensure factory is not registered by some previous test
+		using CredentialCache cache = NewCache();
 
-		// Act
-		var result = cache.TryCreate<CredentialWithNothing>(out var credential);
+		bool result = cache.TryCreate<CredentialWithNothing>(out Credential? credential);
 
-		// Assert
 		Assert.IsFalse(result, "TryCreate should return false when factory is not registered");
 		Assert.IsNull(credential);
 	}
@@ -58,33 +90,12 @@ public class CredentialCacheTests
 	[TestMethod]
 	public void TryCreateCreatesCredentialSuccessfullyWhenFactoryRegistered()
 	{
-		// Arrange
-		var cache = CredentialCache.Instance;
-		var factory = new CredentialWithNothingFactory();
-		cache.RegisterCredentialFactory(factory);
+		using CredentialCache cache = NewCache();
+		cache.RegisterCredentialFactory(new CredentialWithNothingFactory());
 
-		// Act
-		var result = cache.TryCreate<CredentialWithNothing>(out var credential);
+		bool result = cache.TryCreate<CredentialWithNothing>(out Credential? credential);
 
-		// Assert
 		Assert.IsTrue(result, "TryCreate should return true when factory is registered");
-		Assert.IsNotNull(credential);
-		Assert.IsInstanceOfType<CredentialWithNothing>(credential);
-	}
-
-	[TestMethod]
-	public void RegisterCredentialFactoryRegistersFactorySuccessfully()
-	{
-		// Arrange
-		var cache = CredentialCache.Instance;
-		var factory = new CredentialWithNothingFactory();
-
-		// Act
-		cache.RegisterCredentialFactory(factory);
-		var result = cache.TryCreate<CredentialWithNothing>(out var credential);
-
-		// Assert
-		Assert.IsTrue(result, "TryCreate should return true after registering factory");
 		Assert.IsNotNull(credential);
 		Assert.IsInstanceOfType<CredentialWithNothing>(credential);
 	}
@@ -92,16 +103,12 @@ public class CredentialCacheTests
 	[TestMethod]
 	public void UnregisterCredentialFactoryUnregistersFactorySuccessfully()
 	{
-		// Arrange
-		var cache = CredentialCache.Instance;
-		var factory = new CredentialWithNothingFactory();
-		cache.RegisterCredentialFactory(factory);
+		using CredentialCache cache = NewCache();
+		cache.RegisterCredentialFactory(new CredentialWithNothingFactory());
 
-		// Act
 		cache.UnregisterCredentialFactory<CredentialWithNothing>();
-		var result = cache.TryCreate<CredentialWithNothing>(out var credential);
+		bool result = cache.TryCreate<CredentialWithNothing>(out Credential? credential);
 
-		// Assert
 		Assert.IsFalse(result, "TryCreate should return false after unregistering factory");
 		Assert.IsNull(credential);
 	}
@@ -109,123 +116,152 @@ public class CredentialCacheTests
 	[TestMethod]
 	public void UnregisterCredentialFactoryDoesNothingWhenFactoryNotRegistered()
 	{
-		// Arrange
-		var cache = CredentialCache.Instance;
+		using CredentialCache cache = NewCache();
 
-		// Act
 		cache.UnregisterCredentialFactory<CredentialWithNothing>();
-		var result = cache.TryCreate<CredentialWithNothing>(out var credential);
+		bool result = cache.TryCreate<CredentialWithNothing>(out Credential? credential);
 
-		// Assert
-		Assert.IsFalse(result, "TryCreate should return false when factory was never registered");
+		Assert.IsFalse(result);
 		Assert.IsNull(credential);
 	}
 
 	[TestMethod]
 	public void RegisterCredentialFactoryThrowsArgumentNullExceptionWhenFactoryIsNull()
 	{
-		// Arrange
-		var cache = CredentialCache.Instance;
+		using CredentialCache cache = NewCache();
 		ICredentialFactory<CredentialWithNothing>? factory = null;
 
-		// Act & Assert
-		Assert.ThrowsException<ArgumentNullException>(() => cache.RegisterCredentialFactory(factory!));
+		Assert.Throws<ArgumentNullException>(() => cache.RegisterCredentialFactory(factory!));
 	}
 
 	[TestMethod]
 	public void AddOrReplaceThrowsArgumentNullExceptionWhenCredentialIsNull()
 	{
-		// Arrange
-		var cache = CredentialCache.Instance;
-		var guid = CredentialCache.CreatePersonaGUID();
+		using CredentialCache cache = NewCache();
+		PersonaGUID guid = CredentialCache.CreatePersonaGUID();
 		CredentialWithNothing? credential = null;
 
-		// Act & Assert
-		Assert.ThrowsException<ArgumentNullException>(() => cache.AddOrReplace(guid, credential!));
+		Assert.Throws<ArgumentNullException>(() => cache.AddOrReplace(guid, credential!));
+	}
+
+	[TestMethod]
+	public void ConstructorThrowsWhenStoreIsNull()
+	{
+		ICredentialStore? store = null;
+		Assert.Throws<ArgumentNullException>(() => new CredentialCache(store!));
+	}
+
+	[TestMethod]
+	public void OperationsThrowAfterDispose()
+	{
+		CredentialCache cache = NewCache();
+		cache.Dispose();
+
+		Assert.Throws<ObjectDisposedException>(() =>
+			cache.AddOrReplace(CredentialCache.CreatePersonaGUID(), new CredentialWithNothing()));
+		Assert.Throws<ObjectDisposedException>(() =>
+			cache.TryGet(CredentialCache.CreatePersonaGUID(), out _));
+	}
+
+	[TestMethod]
+	public void CredentialSerializationRoundTripsAllKnownTypes()
+	{
+		Credential nothing = new CredentialWithNothing();
+		Credential token = new CredentialWithToken
+		{
+			Token = SemanticString<CredentialToken>.Create("opaque-token"),
+		};
+		Credential creds = new CredentialWithUsernamePassword
+		{
+			Username = SemanticString<CredentialUsername>.Create("u"),
+			Password = SemanticString<CredentialPassword>.Create("p"),
+		};
+
+		foreach (Credential original in new[] { nothing, token, creds })
+		{
+			byte[] bytes = CredentialSerialization.Serialize(original);
+			Credential? deserialized = CredentialSerialization.Deserialize(bytes);
+			Assert.IsNotNull(deserialized);
+			Assert.AreEqual(original.GetType(), deserialized!.GetType());
+		}
 	}
 
 	[TestMethod]
 	public void RegisterMultipleCredentialFactoriesCreatesCredentialsCorrectly()
 	{
-		// Arrange
-		var cache = CredentialCache.Instance;
-		var factory1 = new CredentialWithNothingFactory();
-		var factory2 = new AnotherCredentialFactory();
+		using CredentialCache cache = NewCache();
+		CredentialWithNothingFactory factory1 = new();
+		AnotherCredentialFactory factory2 = new();
 		cache.RegisterCredentialFactory(factory1);
 		cache.RegisterCredentialFactory(factory2);
-		var guid1 = CredentialCache.CreatePersonaGUID();
-		var guid2 = CredentialCache.CreatePersonaGUID();
+		PersonaGUID guid1 = CredentialCache.CreatePersonaGUID();
+		PersonaGUID guid2 = CredentialCache.CreatePersonaGUID();
 
-		// Act
 		cache.AddOrReplace(guid1, factory1.Create());
 		cache.AddOrReplace(guid2, factory2.Create());
-		var result1 = cache.TryGet(guid1, out var credential1);
-		var result2 = cache.TryGet(guid2, out var credential2);
+		bool result1 = cache.TryGet(guid1, out Credential? credential1);
+		bool result2 = cache.TryGet(guid2, out Credential? credential2);
 
-		// Assert
-		Assert.IsTrue(result1, "TryGet should return true for first credential type");
-		Assert.IsNotNull(credential1);
+		Assert.IsTrue(result1);
 		Assert.IsInstanceOfType<CredentialWithNothing>(credential1);
 
-		Assert.IsTrue(result2, "TryGet should return true for second credential type");
-		Assert.IsNotNull(credential2);
+		Assert.IsTrue(result2);
 		Assert.IsInstanceOfType<AnotherCredential>(credential2);
 	}
 
 	[TestMethod]
 	public void CredentialCacheIsThreadSafeUnderConcurrentAccess()
 	{
-		// Arrange
-		var cache = CredentialCache.Instance;
-		var factory = new CredentialWithNothingFactory();
-		cache.RegisterCredentialFactory(factory);
-		var numberOfThreads = 10;
-		var operationsPerThread = 100;
+		using CredentialCache cache = NewCache();
+		cache.RegisterCredentialFactory(new CredentialWithNothingFactory());
+		const int numberOfThreads = 8;
+		const int operationsPerThread = 100;
 		List<Task> tasks = [];
 
-		// Act
-		for (var i = 0; i < numberOfThreads; i++)
+		for (int i = 0; i < numberOfThreads; i++)
 		{
 			tasks.Add(Task.Run(() =>
 			{
-				for (var j = 0; j < operationsPerThread; j++)
+				for (int j = 0; j < operationsPerThread; j++)
 				{
-					var guid = CredentialCache.CreatePersonaGUID();
-					var credential = factory.Create();
+					PersonaGUID guid = CredentialCache.CreatePersonaGUID();
+					CredentialWithNothing credential = new();
 					cache.AddOrReplace(guid, credential);
-					var result = cache.TryGet(guid, out var retrievedCredential);
-					Assert.IsTrue(result, "TryGet should return true under concurrent access");
-					Assert.AreEqual(credential, retrievedCredential);
+					Assert.IsTrue(cache.TryGet(guid, out Credential? retrieved));
+					Assert.AreEqual(credential, retrieved);
 				}
 			}));
 		}
 
 		Task.WaitAll([.. tasks]);
-
-		// Assert
-		// All assertions within tasks are validated
 	}
 
 	[TestMethod]
-	public void UnregisterCredentialFactoryPreventsCredentialCreation()
+	public void ConfigureStoreCannotBeCalledAfterInstanceConstructed()
 	{
-		// Arrange
-		var cache = CredentialCache.Instance;
-		var factory = new CredentialWithNothingFactory();
-		cache.RegisterCredentialFactory(factory);
-		var guid = CredentialCache.CreatePersonaGUID();
-		cache.AddOrReplace(guid, factory.Create());
+		CredentialCache.ResetSingletonForTesting();
+		CredentialCache.ConfigureStore(new InMemoryCredentialStore());
+		_ = CredentialCache.Instance;
+		Assert.Throws<InvalidOperationException>(
+			() => CredentialCache.ConfigureStore(new InMemoryCredentialStore()));
+		CredentialCache.ResetSingletonForTesting();
+	}
 
-		// Act
-		cache.UnregisterCredentialFactory<CredentialWithNothing>();
-		var creationResult = cache.TryCreate<CredentialWithNothing>(out var credentialAfterUnregister);
-		var retrievalResult = cache.TryGet(guid, out var retrievedCredential);
-
-		// Assert
-		Assert.IsFalse(creationResult, "TryCreate should return false after unregistering factory");
-		Assert.IsNull(credentialAfterUnregister);
-		Assert.IsTrue(retrievalResult, "TryGet should return true for previously stored credential");
-		Assert.IsInstanceOfType<CredentialWithNothing>(retrievedCredential);
+	[TestMethod]
+	public void SingletonUsesConfiguredStore()
+	{
+		CredentialCache.ResetSingletonForTesting();
+		InMemoryCredentialStore store = new();
+		CredentialCache.ConfigureStore(store);
+		try
+		{
+			CredentialCache instance = CredentialCache.Instance;
+			Assert.AreSame(store, instance.Store);
+		}
+		finally
+		{
+			CredentialCache.ResetSingletonForTesting();
+		}
 	}
 }
 

--- a/CredentialCache/CredentialCache.cs
+++ b/CredentialCache/CredentialCache.cs
@@ -5,14 +5,8 @@
 namespace ktsu.CredentialCache;
 
 using System.Collections.Concurrent;
-using System.Text.Json.Serialization;
-
-using ktsu.Extensions;
-using ktsu.FileSystemProvider;
-using ktsu.PersistenceProvider;
+using ktsu.CredentialCache.Storage;
 using ktsu.Semantics.Strings;
-using ktsu.UniversalSerializer.Json;
-using ktsu.UniversalSerializer.Services;
 
 /// <summary>
 /// Represents a globally unique identifier for a persona.
@@ -20,65 +14,53 @@ using ktsu.UniversalSerializer.Services;
 public sealed record class PersonaGUID : SemanticString<PersonaGUID> { }
 
 /// <summary>
-/// Data model for credential cache persistence.
-/// </summary>
-internal sealed class CredentialCacheData
-{
-	/// <summary>
-	/// Gets or sets the dictionary of credentials.
-	/// </summary>
-	[JsonInclude]
-	public ConcurrentDictionary<PersonaGUID, Credential> Credentials { get; set; } = new();
-}
-
-/// <summary>
-/// Manages the caching of credentials and their associated factories.
+/// Caches <see cref="Credential"/> instances in memory and persists each one through
+/// an <see cref="ICredentialStore"/>. The default store routes to the platform-native
+/// secret manager:
+/// <list type="bullet">
+///   <item><description>Windows Credential Manager on Windows</description></item>
+///   <item><description>Keychain on macOS</description></item>
+///   <item><description>libsecret (Secret Service) on Linux</description></item>
+/// </list>
 /// </summary>
 public sealed class CredentialCache : IDisposable
 {
-	private const string CacheKey = "CredentialCache";
-	private static readonly object _lock = new();
+	private static readonly Lock _instanceLock = new();
 	private static CredentialCache? _instance;
-	private static IPersistenceProvider<string>? _persistenceProvider;
+	private static ICredentialStore? _configuredStore;
+
+	private readonly ConcurrentDictionary<PersonaGUID, Credential> _credentials = new();
+	private readonly ConcurrentDictionary<Type, ICredentialFactory> _factories = new();
+	private bool _disposed;
 
 	/// <summary>
-	/// Gets the dictionary of credential factories.
+	/// Creates a new credential cache backed by <paramref name="store"/>.
 	/// </summary>
-	private ConcurrentDictionary<Type, ICredentialFactory> CredentialFactories { get; } = new();
-
-	/// <summary>
-	/// Gets the underlying data model.
-	/// </summary>
-	private CredentialCacheData Data { get; set; }
-
-	/// <summary>
-	/// Gets the persistence provider used for storage operations.
-	/// </summary>
-	private IPersistenceProvider<string> PersistenceProvider { get; }
-
-	/// <summary>
-	/// Initializes a new instance of the <see cref="CredentialCache"/> class.
-	/// </summary>
-	/// <param name="persistenceProvider">The persistence provider for storage operations.</param>
-	private CredentialCache(IPersistenceProvider<string> persistenceProvider)
+	/// <param name="store">The store responsible for persistence. Must not be null.</param>
+	public CredentialCache(ICredentialStore store)
 	{
-		PersistenceProvider = persistenceProvider ?? throw new ArgumentNullException(nameof(persistenceProvider));
-		Data = LoadOrCreateData().GetAwaiter().GetResult();
+		ArgumentNullException.ThrowIfNull(store);
+		Store = store;
 	}
 
 	/// <summary>
-	/// Gets the singleton instance of the <see cref="CredentialCache"/> class.
+	/// Gets the process-wide singleton instance, constructed on first access.
 	/// </summary>
+	/// <remarks>
+	/// To override the backing store call <see cref="ConfigureStore"/> before
+	/// touching this property. The first access constructs the singleton; later
+	/// reconfiguration requires <see cref="ResetSingletonForTesting"/>.
+	/// </remarks>
 	public static CredentialCache Instance
 	{
 		get
 		{
-			lock (_lock)
+			lock (_instanceLock)
 			{
 				if (_instance is null)
 				{
-					_persistenceProvider ??= CreateDefaultPersistenceProvider();
-					_instance = new CredentialCache(_persistenceProvider);
+					ICredentialStore store = _configuredStore ?? CredentialStoreFactory.CreateDefault();
+					_instance = new CredentialCache(store);
 				}
 				return _instance;
 			}
@@ -86,70 +68,72 @@ public sealed class CredentialCache : IDisposable
 	}
 
 	/// <summary>
-	/// Configures the persistence provider for the credential cache.
-	/// This must be called before accessing the Instance property if you want to use a custom provider.
+	/// Gets the backing store used by this instance.
 	/// </summary>
-	/// <param name="persistenceProvider">The persistence provider to use.</param>
-	public static void ConfigurePersistenceProvider(IPersistenceProvider<string> persistenceProvider)
+	public ICredentialStore Store { get; }
+
+	/// <summary>
+	/// Configures the <see cref="ICredentialStore"/> used by the singleton
+	/// <see cref="Instance"/>. Must be called before the singleton is first accessed.
+	/// </summary>
+	/// <param name="store">The store to use.</param>
+	/// <exception cref="InvalidOperationException">
+	/// Thrown when the singleton has already been constructed.
+	/// </exception>
+	public static void ConfigureStore(ICredentialStore store)
 	{
-		lock (_lock)
+		ArgumentNullException.ThrowIfNull(store);
+		lock (_instanceLock)
 		{
 			if (_instance is not null)
 			{
-				throw new InvalidOperationException("Cannot configure persistence provider after instance has been created. Call this method before accessing Instance.");
+				throw new InvalidOperationException(
+					$"Cannot configure store after {nameof(Instance)} has been constructed. " +
+					$"Call {nameof(ConfigureStore)} before first access, or " +
+					$"{nameof(ResetSingletonForTesting)} to reset (tests only).");
 			}
-			_persistenceProvider = persistenceProvider ?? throw new ArgumentNullException(nameof(persistenceProvider));
+			_configuredStore = store;
 		}
 	}
 
 	/// <summary>
-	/// Tries to get a credential associated with the specified persona GUID.
+	/// Resets the singleton state so a subsequent <see cref="Instance"/> access constructs
+	/// a fresh cache. Intended for test isolation only.
 	/// </summary>
-	/// <param name="providerGuid">The GUID of the persona.</param>
-	/// <param name="gitCredential">When this method returns, contains the credential associated with the specified GUID, if the GUID is found; otherwise, null.</param>
-	/// <returns><c>true</c> if the credential was found; otherwise, <c>false</c>.</returns>
-	public bool TryGet(PersonaGUID providerGuid, out Credential? gitCredential) =>
-		Data.Credentials.TryGetValue(providerGuid, out gitCredential);
-
-	/// <summary>
-	/// Adds or replaces a credential associated with the specified persona GUID.
-	/// </summary>
-	/// <param name="providerGuid">The GUID of the persona.</param>
-	/// <param name="gitCredential">The credential to add or replace.</param>
-	/// <exception cref="ArgumentNullException">Thrown when <paramref name="gitCredential"/> is null.</exception>
-	public async Task AddOrReplaceAsync(PersonaGUID providerGuid, Credential gitCredential, CancellationToken cancellationToken = default)
+	public static void ResetSingletonForTesting()
 	{
-		ArgumentNullException.ThrowIfNull(gitCredential);
-		Data.Credentials[providerGuid] = gitCredential;
-		await SaveAsync(cancellationToken).ConfigureAwait(false);
-	}
-
-	/// <summary>
-	/// Adds or replaces a credential associated with the specified persona GUID synchronously.
-	/// </summary>
-	/// <param name="providerGuid">The GUID of the persona.</param>
-	/// <param name="gitCredential">The credential to add or replace.</param>
-	/// <exception cref="ArgumentNullException">Thrown when <paramref name="gitCredential"/> is null.</exception>
-	public void AddOrReplace(PersonaGUID providerGuid, Credential gitCredential)
-	{
-		AddOrReplaceAsync(providerGuid, gitCredential).GetAwaiter().GetResult();
-	}
-
-	/// <summary>
-	/// Tries to create a credential of the specified type.
-	/// </summary>
-	/// <typeparam name="T">The type of the credential.</typeparam>
-	/// <param name="credential">When this method returns, contains the created credential, if the factory is found; otherwise, null.</param>
-	/// <returns><c>true</c> if the credential was created; otherwise, <c>false</c>.</returns>
-	public bool TryCreate<T>(out Credential? credential) where T : Credential
-	{
-		if (CredentialFactories.TryGetValue(typeof(T), out var credentialFactory))
+		lock (_instanceLock)
 		{
-			if (credentialFactory is ICredentialFactory<T> factory)
-			{
-				credential = factory.Create();
-				return true;
-			}
+			_instance?.Dispose();
+			_instance = null;
+			_configuredStore = null;
+		}
+	}
+
+	/// <summary>
+	/// Creates a fresh <see cref="PersonaGUID"/>.
+	/// </summary>
+	public static PersonaGUID CreatePersonaGUID() =>
+		SemanticString<PersonaGUID>.Create(Guid.NewGuid().ToString());
+
+	/// <summary>
+	/// Attempts to retrieve the credential associated with <paramref name="persona"/>,
+	/// loading it from the backing store if it has not yet been cached in memory.
+	/// </summary>
+	public bool TryGet(PersonaGUID persona, out Credential? credential)
+	{
+		ArgumentNullException.ThrowIfNull(persona);
+		ThrowIfDisposed();
+
+		if (_credentials.TryGetValue(persona, out credential))
+		{
+			return true;
+		}
+
+		if (Store.TryLoad(persona, out Credential? loaded) && loaded is not null)
+		{
+			credential = _credentials.GetOrAdd(persona, loaded);
+			return true;
 		}
 
 		credential = null;
@@ -157,80 +141,82 @@ public sealed class CredentialCache : IDisposable
 	}
 
 	/// <summary>
-	/// Creates a new persona GUID.
+	/// Adds or replaces the credential for <paramref name="persona"/> and persists it.
 	/// </summary>
-	/// <returns>A new <see cref="PersonaGUID"/>.</returns>
-	public static PersonaGUID CreatePersonaGUID() => Guid.NewGuid().ToString().As<PersonaGUID>();
+	public void AddOrReplace(PersonaGUID persona, Credential credential)
+	{
+		ArgumentNullException.ThrowIfNull(persona);
+		ArgumentNullException.ThrowIfNull(credential);
+		ThrowIfDisposed();
+
+		_credentials[persona] = credential;
+		Store.Save(persona, credential);
+	}
 
 	/// <summary>
-	/// Registers a credential factory for the specified credential type.
+	/// Removes the credential associated with <paramref name="persona"/> from both
+	/// the in-memory cache and the backing store.
 	/// </summary>
-	/// <typeparam name="T">The type of the credential.</typeparam>
-	/// <param name="factory">The factory to register.</param>
-	/// <exception cref="ArgumentNullException">Thrown when <paramref name="factory"/> is null.</exception>
+	public bool Remove(PersonaGUID persona)
+	{
+		ArgumentNullException.ThrowIfNull(persona);
+		ThrowIfDisposed();
+
+		bool removedInMemory = _credentials.TryRemove(persona, out _);
+		bool removedFromStore = Store.Remove(persona);
+		return removedInMemory || removedFromStore;
+	}
+
+	/// <summary>
+	/// Registers a factory for credentials of type <typeparamref name="T"/>.
+	/// </summary>
 	public void RegisterCredentialFactory<T>(ICredentialFactory<T> factory) where T : Credential
 	{
 		ArgumentNullException.ThrowIfNull(factory);
-		CredentialFactories[typeof(T)] = factory;
+		ThrowIfDisposed();
+		_factories[typeof(T)] = factory;
 	}
 
 	/// <summary>
-	/// Unregisters a credential factory for the specified credential type.
+	/// Unregisters any factory previously registered for type <typeparamref name="T"/>.
 	/// </summary>
-	/// <typeparam name="T">The type of the credential.</typeparam>
-	public void UnregisterCredentialFactory<T>() where T : Credential =>
-		CredentialFactories.TryRemove(typeof(T), out _);
-
-	/// <summary>
-	/// Saves the current credential cache data to persistent storage.
-	/// </summary>
-	/// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-	/// <returns>A task that represents the asynchronous save operation.</returns>
-	public async Task SaveAsync(CancellationToken cancellationToken = default)
+	public void UnregisterCredentialFactory<T>() where T : Credential
 	{
-		await PersistenceProvider.StoreAsync(CacheKey, Data, cancellationToken).ConfigureAwait(false);
+		ThrowIfDisposed();
+		_factories.TryRemove(typeof(T), out _);
 	}
 
 	/// <summary>
-	/// Saves the current credential cache data to persistent storage synchronously.
+	/// Attempts to create a credential of type <typeparamref name="T"/> using a previously
+	/// registered factory.
 	/// </summary>
-	public void Save()
+	public bool TryCreate<T>(out Credential? credential) where T : Credential
 	{
-		SaveAsync().GetAwaiter().GetResult();
+		ThrowIfDisposed();
+		if (_factories.TryGetValue(typeof(T), out ICredentialFactory? factory) && factory is ICredentialFactory<T> typed)
+		{
+			credential = typed.Create();
+			return true;
+		}
+		credential = null;
+		return false;
 	}
 
-	/// <summary>
-	/// Loads or creates the credential cache data from persistent storage.
-	/// </summary>
-	/// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
-	/// <returns>The loaded or newly created credential cache data.</returns>
-	private async Task<CredentialCacheData> LoadOrCreateData(CancellationToken cancellationToken = default)
-	{
-		return await PersistenceProvider.RetrieveOrCreateAsync<CredentialCacheData>(CacheKey, cancellationToken).ConfigureAwait(false);
-	}
+	private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
 
 	/// <summary>
-	/// Creates the default persistence provider for the credential cache.
-	/// </summary>
-	/// <returns>A new instance of the default persistence provider.</returns>
-	private static IPersistenceProvider<string> CreateDefaultPersistenceProvider()
-	{
-		var fileSystemProvider = new FileSystemProvider();
-		var jsonSerializer = new JsonSerializer();
-		var serializationProvider = new UniversalSerializationProvider(jsonSerializer, providerName: "CredentialCache.Json");
-		return new AppDataPersistenceProvider<string>(
-			fileSystemProvider,
-			serializationProvider,
-			applicationName: "ktsu",
-			subdirectory: "CredentialCache");
-	}
-
-	/// <summary>
-	/// Disposes the credential cache instance and saves any pending changes.
+	/// Releases the in-memory state. Stored credentials remain in the backing
+	/// store; nothing is persisted or deleted at dispose-time because every
+	/// mutation is already flushed eagerly in <see cref="AddOrReplace"/>.
 	/// </summary>
 	public void Dispose()
 	{
-		Save();
+		if (_disposed)
+		{
+			return;
+		}
+		_disposed = true;
+		_credentials.Clear();
+		_factories.Clear();
 	}
 }
-

--- a/CredentialCache/CredentialCache.csproj
+++ b/CredentialCache/CredentialCache.csproj
@@ -1,15 +1,23 @@
-﻿<Project>
+<Project>
   <Sdk Name="Microsoft.NET.Sdk" />
   <Sdk Name="ktsu.Sdk" />
 
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <!--
+      Library-level suppressions:
+      KTSU0003 - prefer the BCL ArgumentNullException.ThrowIfNull over Polyfill Ensure.NotNull (the targeted frameworks all support it).
+      SYSLIB1054 - LibraryImport source generation isn't supportable for the libsecret / Security.framework paths we touch here; DllImport is correct.
+      CA5392    - DefaultDllImportSearchPaths is unnecessary for absolute-path imports (Security.framework) and irrelevant for libsecret/advapi32.
+      CA1031    - libsecret error extraction must remain best-effort and never mask the real failure.
+    -->
+    <NoWarn>$(NoWarn);KTSU0003;SYSLIB1054;CA5392;CA1031;CA1416</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="ktsu.AppDataStorage" />
-    <PackageReference Include="ktsu.Extensions" />
-    <PackageReference Include="ktsu.FileSystemProvider" />
-    <PackageReference Include="ktsu.PersistenceProvider" />
-    <PackageReference Include="ktsu.UniversalSerializer" />
     <PackageReference Include="ktsu.Semantics.Strings" />
-    <PackageReference Include="ktsu.Semantics.Paths" />
+    <PackageReference Include="ktsu.RoundTripStringJsonConverter" />
     <PackageReference Include="Polyfill" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" />
     <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" />

--- a/CredentialCache/CredentialWithUsernamePassword.cs
+++ b/CredentialCache/CredentialWithUsernamePassword.cs
@@ -10,10 +10,12 @@ using ktsu.Semantics.Strings;
 /// Represents a credential with a username.
 /// </summary>
 public sealed record class CredentialUsername : SemanticString<CredentialUsername> { }
+
 /// <summary>
 /// Represents a credential with a password.
 /// </summary>
 public sealed record class CredentialPassword : SemanticString<CredentialPassword> { }
+
 /// <summary>
 /// Represents a credential that includes both a username and a password.
 /// </summary>

--- a/CredentialCache/ICredentialFactory.cs
+++ b/CredentialCache/ICredentialFactory.cs
@@ -7,7 +7,7 @@ namespace ktsu.CredentialCache;
 /// <summary>
 /// Represents a factory for creating credentials.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1040:Avoid empty interfaces", Justification = "I'm using this as the base for the generic")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1040:Avoid empty interfaces", Justification = "Base for the generic factory interface.")]
 public interface ICredentialFactory { }
 
 /// <summary>

--- a/CredentialCache/Storage/CredentialSerialization.cs
+++ b/CredentialCache/Storage/CredentialSerialization.cs
@@ -1,0 +1,85 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.CredentialCache.Storage;
+
+using System.Text.Json;
+using ktsu.RoundTripStringJsonConverter;
+
+/// <summary>
+/// Serializes <see cref="Credential"/> instances to and from UTF-8 JSON. Custom
+/// <see cref="ICredentialStore"/> implementations should round-trip credentials
+/// through these helpers so polymorphic <see cref="Credential"/> subclasses are
+/// preserved.
+/// </summary>
+public static class CredentialSerialization
+{
+	private static readonly JsonSerializerOptions Options = BuildOptions();
+
+	private static JsonSerializerOptions BuildOptions()
+	{
+		JsonSerializerOptions options = new()
+		{
+			WriteIndented = false,
+		};
+		// Persuade System.Text.Json to use the SemanticString factory methods (Create / FromString)
+		// rather than treating SemanticString<T> as an IEnumerable<char> collection.
+		options.Converters.Add(new RoundTripStringJsonConverterFactory());
+		return options;
+	}
+
+	/// <summary>
+	/// Serializes the credential to a UTF-8 JSON byte array.
+	/// </summary>
+	public static byte[] Serialize(Credential credential) =>
+		JsonSerializer.SerializeToUtf8Bytes(credential, Options);
+
+	/// <summary>
+	/// Serializes the credential to a UTF-8 JSON string.
+	/// </summary>
+	public static string SerializeToString(Credential credential) =>
+		JsonSerializer.Serialize(credential, Options);
+
+	/// <summary>
+	/// Deserializes a credential from a UTF-8 JSON byte array. Returns <c>null</c> if the bytes
+	/// do not represent a known credential.
+	/// </summary>
+	public static Credential? Deserialize(byte[] utf8Json)
+	{
+		if (utf8Json is null || utf8Json.Length == 0)
+		{
+			return null;
+		}
+
+		try
+		{
+			return JsonSerializer.Deserialize<Credential>(utf8Json, Options);
+		}
+		catch (JsonException)
+		{
+			return null;
+		}
+	}
+
+	/// <summary>
+	/// Deserializes a credential from a UTF-8 JSON string. Returns <c>null</c> if the value
+	/// does not represent a known credential.
+	/// </summary>
+	public static Credential? DeserializeFromString(string utf8Json)
+	{
+		if (string.IsNullOrEmpty(utf8Json))
+		{
+			return null;
+		}
+
+		try
+		{
+			return JsonSerializer.Deserialize<Credential>(utf8Json, Options);
+		}
+		catch (JsonException)
+		{
+			return null;
+		}
+	}
+}

--- a/CredentialCache/Storage/CredentialStoreException.cs
+++ b/CredentialCache/Storage/CredentialStoreException.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.CredentialCache.Storage;
+
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Raised when an operation against the underlying OS credential store fails.
+/// </summary>
+[SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "Always raised with detail.")]
+public sealed class CredentialStoreException : Exception
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="CredentialStoreException"/> class.
+	/// </summary>
+	public CredentialStoreException(string message) : base(message) { }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="CredentialStoreException"/> class.
+	/// </summary>
+	public CredentialStoreException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/CredentialCache/Storage/CredentialStoreFactory.cs
+++ b/CredentialCache/Storage/CredentialStoreFactory.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.CredentialCache.Storage;
+
+using System.Runtime.InteropServices;
+
+/// <summary>
+/// Selects the appropriate <see cref="ICredentialStore"/> implementation for the
+/// current operating system.
+/// </summary>
+public static class CredentialStoreFactory
+{
+	/// <summary>
+	/// Returns the default platform-native credential store for the current OS.
+	/// </summary>
+	/// <param name="serviceName">
+	/// A logical service name used to scope the stored credentials. Defaults to
+	/// <c>ktsu.CredentialCache</c>. Use a per-application name when several
+	/// applications share a host to avoid collisions.
+	/// </param>
+	/// <exception cref="PlatformNotSupportedException">
+	/// Thrown when the current platform is not Windows, macOS, or Linux.
+	/// </exception>
+	public static ICredentialStore CreateDefault(string serviceName = "ktsu.CredentialCache")
+	{
+		ArgumentException.ThrowIfNullOrEmpty(serviceName);
+
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		{
+			return new WindowsCredentialStore(serviceName);
+		}
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+		{
+			return new MacOsCredentialStore(serviceName);
+		}
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+		{
+			return new LinuxSecretServiceCredentialStore(serviceName);
+		}
+
+		throw new PlatformNotSupportedException(
+			$"CredentialCache has no native credential store for '{RuntimeInformation.OSDescription}'. " +
+			$"Use {nameof(InMemoryCredentialStore)} or supply a custom {nameof(ICredentialStore)} implementation.");
+	}
+}

--- a/CredentialCache/Storage/ICredentialStore.cs
+++ b/CredentialCache/Storage/ICredentialStore.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.CredentialCache.Storage;
+
+/// <summary>
+/// Persists <see cref="Credential"/> instances keyed by <see cref="PersonaGUID"/>.
+/// Implementations are expected to delegate the at-rest protection of secrets
+/// to the platform's native credential store (Windows Credential Manager, macOS
+/// Keychain, Linux libsecret) or to an explicit in-memory backing.
+/// </summary>
+public interface ICredentialStore
+{
+	/// <summary>
+	/// Gets a human-readable name identifying the backing store (for diagnostics).
+	/// </summary>
+	public string Name { get; }
+
+	/// <summary>
+	/// Attempts to load the credential associated with <paramref name="persona"/>.
+	/// </summary>
+	public bool TryLoad(PersonaGUID persona, out Credential? credential);
+
+	/// <summary>
+	/// Stores or replaces the credential associated with <paramref name="persona"/>.
+	/// </summary>
+	public void Save(PersonaGUID persona, Credential credential);
+
+	/// <summary>
+	/// Removes any credential associated with <paramref name="persona"/>.
+	/// </summary>
+	public bool Remove(PersonaGUID persona);
+
+	/// <summary>
+	/// Enumerates every persona key currently stored.
+	/// </summary>
+	public IEnumerable<PersonaGUID> EnumerateKeys();
+}

--- a/CredentialCache/Storage/InMemoryCredentialStore.cs
+++ b/CredentialCache/Storage/InMemoryCredentialStore.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.CredentialCache.Storage;
+
+using System.Collections.Concurrent;
+
+/// <summary>
+/// A non-persistent credential store backed by an in-memory dictionary. Intended for
+/// tests and applications that explicitly opt out of platform-level persistence.
+/// </summary>
+public sealed class InMemoryCredentialStore : ICredentialStore
+{
+
+	private readonly ConcurrentDictionary<PersonaGUID, Credential> _items = new();
+
+	/// <inheritdoc/>
+
+	public string Name => "InMemory";
+
+	/// <inheritdoc/>
+	public bool TryLoad(PersonaGUID persona, out Credential? credential)
+	{
+		ArgumentNullException.ThrowIfNull(persona);
+		return _items.TryGetValue(persona, out credential);
+
+	}
+
+	/// <inheritdoc/>
+	public void Save(PersonaGUID persona, Credential credential)
+	{
+		ArgumentNullException.ThrowIfNull(persona);
+		ArgumentNullException.ThrowIfNull(credential);
+		_items[persona] = credential;
+
+	}
+
+	/// <inheritdoc/>
+	public bool Remove(PersonaGUID persona)
+	{
+		ArgumentNullException.ThrowIfNull(persona);
+		return _items.TryRemove(persona, out _);
+
+	}
+
+	/// <inheritdoc/>
+	public IEnumerable<PersonaGUID> EnumerateKeys() => [.. _items.Keys];
+}

--- a/CredentialCache/Storage/LinuxSecretServiceCredentialStore.cs
+++ b/CredentialCache/Storage/LinuxSecretServiceCredentialStore.cs
@@ -1,0 +1,213 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.CredentialCache.Storage;
+
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+/// <summary>
+/// A credential store backed by the freedesktop.org Secret Service API via
+/// <c>libsecret-1.so.0</c>. Each <see cref="PersonaGUID"/> is stored as an item in the
+/// default collection (typically the user's login keyring) with attributes
+/// <c>service</c> and <c>account</c> identifying it.
+/// </summary>
+/// <remarks>
+/// Requires libsecret to be installed on the host. On headless systems without
+/// a running secret-service implementation (e.g. minimal containers, build agents)
+/// this provider will fail at the first operation; consumers should detect this
+/// and fall back to <see cref="InMemoryCredentialStore"/> if appropriate.
+/// </remarks>
+[SupportedOSPlatform("linux")]
+internal sealed class LinuxSecretServiceCredentialStore : ICredentialStore
+{
+	internal const string DefaultServiceName = "ktsu.CredentialCache";
+
+	private readonly string _serviceName;
+
+	public LinuxSecretServiceCredentialStore(string serviceName = DefaultServiceName)
+	{
+		ArgumentException.ThrowIfNullOrEmpty(serviceName);
+		_serviceName = serviceName;
+	}
+
+	/// <inheritdoc/>
+	public string Name => "Linux libsecret (Secret Service)";
+
+	/// <inheritdoc/>
+	public bool TryLoad(PersonaGUID persona, out Credential? credential)
+	{
+		ArgumentNullException.ThrowIfNull(persona);
+		credential = null;
+
+		IntPtr error = IntPtr.Zero;
+		IntPtr passwordPtr = NativeMethods.secret_password_lookup_sync(
+			Schema.Handle,
+			IntPtr.Zero,
+			ref error,
+			"service", _serviceName,
+			"account", persona.ToString(),
+			IntPtr.Zero);
+
+		ThrowIfError(error, "secret_password_lookup_sync");
+
+		if (passwordPtr == IntPtr.Zero)
+		{
+			return false;
+		}
+
+		try
+		{
+			string? value = Marshal.PtrToStringUTF8(passwordPtr);
+			if (string.IsNullOrEmpty(value))
+			{
+				return false;
+			}
+			credential = CredentialSerialization.DeserializeFromString(value);
+			return credential is not null;
+		}
+		finally
+		{
+			NativeMethods.secret_password_free(passwordPtr);
+		}
+	}
+
+	/// <inheritdoc/>
+	public void Save(PersonaGUID persona, Credential credential)
+	{
+		ArgumentNullException.ThrowIfNull(persona);
+		ArgumentNullException.ThrowIfNull(credential);
+
+		string value = CredentialSerialization.SerializeToString(credential);
+		string label = $"{_serviceName}:{persona}";
+
+		IntPtr error = IntPtr.Zero;
+		bool stored = NativeMethods.secret_password_store_sync(
+			Schema.Handle,
+			IntPtr.Zero,
+			label,
+			value,
+			IntPtr.Zero,
+			ref error,
+			"service", _serviceName,
+			"account", persona.ToString(),
+			IntPtr.Zero);
+
+		ThrowIfError(error, "secret_password_store_sync");
+
+		if (!stored)
+		{
+			throw new CredentialStoreException($"secret_password_store_sync returned false for '{persona}'.");
+		}
+	}
+
+	/// <inheritdoc/>
+	public bool Remove(PersonaGUID persona)
+	{
+		ArgumentNullException.ThrowIfNull(persona);
+
+		IntPtr error = IntPtr.Zero;
+		bool removed = NativeMethods.secret_password_clear_sync(
+			Schema.Handle,
+			IntPtr.Zero,
+			ref error,
+			"service", _serviceName,
+			"account", persona.ToString(),
+			IntPtr.Zero);
+
+		ThrowIfError(error, "secret_password_clear_sync");
+		return removed;
+	}
+
+	/// <inheritdoc/>
+	public IEnumerable<PersonaGUID> EnumerateKeys()
+	{
+		// libsecret search_sync requires GLib list/hash-table marshalling. Callers
+		// needing enumeration can track keys themselves or rely on the in-memory
+		// snapshot maintained by <see cref="CredentialCache"/>.
+		yield break;
+	}
+
+	private static void ThrowIfError(IntPtr error, string operation)
+	{
+		if (error == IntPtr.Zero)
+		{
+			return;
+		}
+		string? message = null;
+		try
+		{
+			IntPtr messagePtr = Marshal.ReadIntPtr(error, IntPtr.Size * 2);
+			message = Marshal.PtrToStringUTF8(messagePtr);
+		}
+		catch
+		{
+			// Best-effort: message extraction shouldn't mask the real failure.
+		}
+		finally
+		{
+			NativeMethods.g_error_free(error);
+		}
+
+		throw new CredentialStoreException($"{operation} failed: {message ?? "<no detail>"}");
+	}
+
+	private static class Schema
+	{
+		internal static readonly IntPtr Handle = NativeMethods.secret_schema_new(
+			"dev.ktsu.CredentialCache",
+			flags: 0,
+			"service", 0,
+			"account", 0,
+			IntPtr.Zero);
+	}
+
+	private static class NativeMethods
+	{
+		private const string Lib = "libsecret-1.so.0";
+
+		[DllImport(Lib, CharSet = CharSet.Ansi)]
+		internal static extern IntPtr secret_schema_new(
+			string name, int flags,
+			string attribute1Name, int attribute1Type,
+			string attribute2Name, int attribute2Type,
+			IntPtr terminator);
+
+		[DllImport(Lib, CharSet = CharSet.Ansi)]
+		internal static extern IntPtr secret_password_lookup_sync(
+			IntPtr schema,
+			IntPtr cancellable,
+			ref IntPtr error,
+			string attribute1Name, string attribute1Value,
+			string attribute2Name, string attribute2Value,
+			IntPtr terminator);
+
+		[DllImport(Lib, CharSet = CharSet.Ansi)]
+		internal static extern void secret_password_free(IntPtr password);
+
+		[DllImport(Lib, CharSet = CharSet.Ansi)]
+		internal static extern bool secret_password_store_sync(
+			IntPtr schema,
+			IntPtr collection,
+			string label,
+			string password,
+			IntPtr cancellable,
+			ref IntPtr error,
+			string attribute1Name, string attribute1Value,
+			string attribute2Name, string attribute2Value,
+			IntPtr terminator);
+
+		[DllImport(Lib, CharSet = CharSet.Ansi)]
+		internal static extern bool secret_password_clear_sync(
+			IntPtr schema,
+			IntPtr cancellable,
+			ref IntPtr error,
+			string attribute1Name, string attribute1Value,
+			string attribute2Name, string attribute2Value,
+			IntPtr terminator);
+
+		[DllImport("libglib-2.0.so.0")]
+		internal static extern void g_error_free(IntPtr error);
+	}
+}

--- a/CredentialCache/Storage/MacOsCredentialStore.cs
+++ b/CredentialCache/Storage/MacOsCredentialStore.cs
@@ -1,0 +1,242 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.CredentialCache.Storage;
+
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Text;
+
+/// <summary>
+/// A credential store backed by the macOS Keychain Services API. Each
+/// <see cref="PersonaGUID"/> is stored as a <c>kSecClassGenericPassword</c> item with the
+/// service name set to <see cref="DefaultServiceName"/> (overridable) and the account
+/// name set to the persona GUID.
+/// </summary>
+[SupportedOSPlatform("osx")]
+internal sealed class MacOsCredentialStore : ICredentialStore
+{
+	internal const string DefaultServiceName = "ktsu.CredentialCache";
+
+	private readonly string _serviceName;
+
+	public MacOsCredentialStore(string serviceName = DefaultServiceName)
+	{
+		ArgumentException.ThrowIfNullOrEmpty(serviceName);
+		_serviceName = serviceName;
+	}
+
+	/// <inheritdoc/>
+	public string Name => "macOS Keychain";
+
+	/// <inheritdoc/>
+	public bool TryLoad(PersonaGUID persona, out Credential? credential)
+	{
+		ArgumentNullException.ThrowIfNull(persona);
+		credential = null;
+
+		byte[] account = Encoding.UTF8.GetBytes(persona.ToString());
+		byte[] service = Encoding.UTF8.GetBytes(_serviceName);
+
+		int status = NativeMethods.SecKeychainFindGenericPassword(
+			keychainOrArray: IntPtr.Zero,
+			serviceNameLength: (uint)service.Length, serviceName: service,
+			accountNameLength: (uint)account.Length, accountName: account,
+			passwordLength: out uint length, passwordData: out IntPtr passwordPtr,
+			itemRef: IntPtr.Zero);
+
+		if (status == NativeMethods.errSecItemNotFound)
+		{
+			return false;
+		}
+		if (status != NativeMethods.errSecSuccess)
+		{
+			throw new CredentialStoreException($"SecKeychainFindGenericPassword failed ({status}).");
+		}
+
+		try
+		{
+			byte[] blob = new byte[length];
+			Marshal.Copy(passwordPtr, blob, 0, (int)length);
+			credential = CredentialSerialization.Deserialize(blob);
+			Array.Clear(blob, 0, blob.Length);
+			return credential is not null;
+		}
+		finally
+		{
+			_ = NativeMethods.SecKeychainItemFreeContent(IntPtr.Zero, passwordPtr);
+		}
+	}
+
+	/// <inheritdoc/>
+	public void Save(PersonaGUID persona, Credential credential)
+	{
+		ArgumentNullException.ThrowIfNull(persona);
+		ArgumentNullException.ThrowIfNull(credential);
+
+		byte[] account = Encoding.UTF8.GetBytes(persona.ToString());
+		byte[] service = Encoding.UTF8.GetBytes(_serviceName);
+		byte[] blob = CredentialSerialization.Serialize(credential);
+
+		try
+		{
+			int findStatus = NativeMethods.SecKeychainFindGenericPasswordWithRef(
+				keychainOrArray: IntPtr.Zero,
+				serviceNameLength: (uint)service.Length, serviceName: service,
+				accountNameLength: (uint)account.Length, accountName: account,
+				passwordLength: out _, passwordData: out IntPtr existingPtr,
+				itemRef: out IntPtr itemRef);
+
+			if (findStatus == NativeMethods.errSecSuccess)
+			{
+				try
+				{
+					int modifyStatus = NativeMethods.SecKeychainItemModifyAttributesAndData(
+						itemRef, attrList: IntPtr.Zero,
+						length: (uint)blob.Length, data: blob);
+					if (modifyStatus != NativeMethods.errSecSuccess)
+					{
+						throw new CredentialStoreException(
+							$"SecKeychainItemModifyAttributesAndData failed ({modifyStatus}).");
+					}
+				}
+				finally
+				{
+					if (existingPtr != IntPtr.Zero)
+					{
+						_ = NativeMethods.SecKeychainItemFreeContent(IntPtr.Zero, existingPtr);
+					}
+					if (itemRef != IntPtr.Zero)
+					{
+						NativeMethods.CFRelease(itemRef);
+					}
+				}
+				return;
+			}
+			if (findStatus != NativeMethods.errSecItemNotFound)
+			{
+				throw new CredentialStoreException($"SecKeychainFindGenericPassword failed ({findStatus}).");
+			}
+
+			int addStatus = NativeMethods.SecKeychainAddGenericPassword(
+				keychain: IntPtr.Zero,
+				serviceNameLength: (uint)service.Length, serviceName: service,
+				accountNameLength: (uint)account.Length, accountName: account,
+				passwordLength: (uint)blob.Length, passwordData: blob,
+				itemRef: IntPtr.Zero);
+
+			if (addStatus != NativeMethods.errSecSuccess)
+			{
+				throw new CredentialStoreException($"SecKeychainAddGenericPassword failed ({addStatus}).");
+			}
+		}
+		finally
+		{
+			Array.Clear(blob, 0, blob.Length);
+		}
+	}
+
+	/// <inheritdoc/>
+	public bool Remove(PersonaGUID persona)
+	{
+		ArgumentNullException.ThrowIfNull(persona);
+
+		byte[] account = Encoding.UTF8.GetBytes(persona.ToString());
+		byte[] service = Encoding.UTF8.GetBytes(_serviceName);
+
+		int findStatus = NativeMethods.SecKeychainFindGenericPasswordWithRef(
+			keychainOrArray: IntPtr.Zero,
+			serviceNameLength: (uint)service.Length, serviceName: service,
+			accountNameLength: (uint)account.Length, accountName: account,
+			passwordLength: out _, passwordData: out IntPtr passwordPtr,
+			itemRef: out IntPtr itemRef);
+
+		if (findStatus == NativeMethods.errSecItemNotFound)
+		{
+			return false;
+		}
+		if (findStatus != NativeMethods.errSecSuccess)
+		{
+			throw new CredentialStoreException($"SecKeychainFindGenericPassword failed ({findStatus}).");
+		}
+
+		try
+		{
+			int deleteStatus = NativeMethods.SecKeychainItemDelete(itemRef);
+			if (deleteStatus != NativeMethods.errSecSuccess)
+			{
+				throw new CredentialStoreException($"SecKeychainItemDelete failed ({deleteStatus}).");
+			}
+			return true;
+		}
+		finally
+		{
+			if (passwordPtr != IntPtr.Zero)
+			{
+				_ = NativeMethods.SecKeychainItemFreeContent(IntPtr.Zero, passwordPtr);
+			}
+			if (itemRef != IntPtr.Zero)
+			{
+				NativeMethods.CFRelease(itemRef);
+			}
+		}
+	}
+
+	/// <inheritdoc/>
+	public IEnumerable<PersonaGUID> EnumerateKeys()
+	{
+		// SecItemCopyMatching with a CFDictionary is required for enumeration. Implementing
+		// the CoreFoundation marshalling for an enumerate-only path adds substantial native
+		// surface; callers that need enumeration can track keys themselves or rely on the
+		// in-memory snapshot maintained by <see cref="CredentialCache"/>.
+		yield break;
+	}
+
+	private static class NativeMethods
+	{
+		internal const int errSecSuccess = 0;
+		internal const int errSecItemNotFound = -25300;
+
+		private const string Security = "/System/Library/Frameworks/Security.framework/Security";
+		private const string CoreFoundation = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
+
+		[DllImport(Security)]
+		internal static extern int SecKeychainFindGenericPassword(
+			IntPtr keychainOrArray,
+			uint serviceNameLength, byte[] serviceName,
+			uint accountNameLength, byte[] accountName,
+			out uint passwordLength, out IntPtr passwordData,
+			IntPtr itemRef);
+
+		[DllImport(Security, EntryPoint = "SecKeychainFindGenericPassword")]
+		internal static extern int SecKeychainFindGenericPasswordWithRef(
+			IntPtr keychainOrArray,
+			uint serviceNameLength, byte[] serviceName,
+			uint accountNameLength, byte[] accountName,
+			out uint passwordLength, out IntPtr passwordData,
+			out IntPtr itemRef);
+
+		[DllImport(Security)]
+		internal static extern int SecKeychainAddGenericPassword(
+			IntPtr keychain,
+			uint serviceNameLength, byte[] serviceName,
+			uint accountNameLength, byte[] accountName,
+			uint passwordLength, byte[] passwordData,
+			IntPtr itemRef);
+
+		[DllImport(Security)]
+		internal static extern int SecKeychainItemModifyAttributesAndData(
+			IntPtr itemRef, IntPtr attrList,
+			uint length, byte[] data);
+
+		[DllImport(Security)]
+		internal static extern int SecKeychainItemDelete(IntPtr itemRef);
+
+		[DllImport(Security)]
+		internal static extern int SecKeychainItemFreeContent(IntPtr attrList, IntPtr data);
+
+		[DllImport(CoreFoundation)]
+		internal static extern void CFRelease(IntPtr cf);
+	}
+}

--- a/CredentialCache/Storage/WindowsCredentialStore.cs
+++ b/CredentialCache/Storage/WindowsCredentialStore.cs
@@ -1,0 +1,212 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.CredentialCache.Storage;
+
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using ktsu.Semantics.Strings;
+
+/// <summary>
+/// A credential store backed by Windows Credential Manager (advapi32). Each
+/// <see cref="PersonaGUID"/> is stored as a generic credential whose target name is
+/// <c>{ServicePrefix}:{persona}</c> and whose <c>CredentialBlob</c> is the UTF-8 JSON
+/// representation of the <see cref="Credential"/>.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal sealed class WindowsCredentialStore : ICredentialStore
+{
+	internal const string DefaultServicePrefix = "ktsu.CredentialCache";
+
+	private readonly string _servicePrefix;
+
+	public WindowsCredentialStore(string servicePrefix = DefaultServicePrefix)
+	{
+		ArgumentException.ThrowIfNullOrEmpty(servicePrefix);
+		_servicePrefix = servicePrefix;
+	}
+
+	/// <inheritdoc/>
+	public string Name => "Windows Credential Manager";
+
+	private string TargetFor(PersonaGUID persona) => $"{_servicePrefix}:{persona}";
+
+	/// <inheritdoc/>
+	public bool TryLoad(PersonaGUID persona, out Credential? credential)
+	{
+		ArgumentNullException.ThrowIfNull(persona);
+		credential = null;
+
+		if (!NativeMethods.CredRead(TargetFor(persona), NativeMethods.CRED_TYPE_GENERIC, 0, out nint handle))
+		{
+			int err = Marshal.GetLastWin32Error();
+			if (err == NativeMethods.ERROR_NOT_FOUND)
+			{
+				return false;
+			}
+			throw new CredentialStoreException($"CredRead failed for '{persona}'.", new Win32Exception(err));
+		}
+
+		try
+		{
+			NativeMethods.CREDENTIAL cred = Marshal.PtrToStructure<NativeMethods.CREDENTIAL>(handle);
+			if (cred.CredentialBlob == IntPtr.Zero || cred.CredentialBlobSize == 0)
+			{
+				return false;
+			}
+
+			byte[] blob = new byte[cred.CredentialBlobSize];
+			Marshal.Copy(cred.CredentialBlob, blob, 0, blob.Length);
+			credential = CredentialSerialization.Deserialize(blob);
+			return credential is not null;
+		}
+		finally
+		{
+			NativeMethods.CredFree(handle);
+		}
+	}
+
+	/// <inheritdoc/>
+	public void Save(PersonaGUID persona, Credential credential)
+	{
+		ArgumentNullException.ThrowIfNull(persona);
+		ArgumentNullException.ThrowIfNull(credential);
+
+		byte[] blob = CredentialSerialization.Serialize(credential);
+		if (blob.Length > NativeMethods.CRED_MAX_CREDENTIAL_BLOB_SIZE)
+		{
+			throw new CredentialStoreException(
+				$"Credential exceeds the Windows Credential Manager blob size limit of " +
+				$"{NativeMethods.CRED_MAX_CREDENTIAL_BLOB_SIZE} bytes (was {blob.Length}).");
+		}
+
+		IntPtr blobPtr = Marshal.AllocHGlobal(blob.Length);
+		try
+		{
+			Marshal.Copy(blob, 0, blobPtr, blob.Length);
+
+			NativeMethods.CREDENTIAL native = new()
+			{
+				Type = NativeMethods.CRED_TYPE_GENERIC,
+				TargetName = TargetFor(persona),
+				CredentialBlob = blobPtr,
+				CredentialBlobSize = blob.Length,
+				Persist = NativeMethods.CRED_PERSIST_LOCAL_MACHINE,
+				UserName = Environment.UserName,
+			};
+
+			if (!NativeMethods.CredWrite(ref native, 0))
+			{
+				int err = Marshal.GetLastWin32Error();
+				throw new CredentialStoreException($"CredWrite failed for '{persona}'.", new Win32Exception(err));
+			}
+		}
+		finally
+		{
+			Marshal.FreeHGlobal(blobPtr);
+			Array.Clear(blob, 0, blob.Length);
+		}
+	}
+
+	/// <inheritdoc/>
+	public bool Remove(PersonaGUID persona)
+	{
+		ArgumentNullException.ThrowIfNull(persona);
+		if (NativeMethods.CredDelete(TargetFor(persona), NativeMethods.CRED_TYPE_GENERIC, 0))
+		{
+			return true;
+		}
+		int err = Marshal.GetLastWin32Error();
+		if (err == NativeMethods.ERROR_NOT_FOUND)
+		{
+			return false;
+		}
+		throw new CredentialStoreException($"CredDelete failed for '{persona}'.", new Win32Exception(err));
+	}
+
+	/// <inheritdoc/>
+	public IEnumerable<PersonaGUID> EnumerateKeys()
+	{
+		string filter = $"{_servicePrefix}:*";
+		if (!NativeMethods.CredEnumerate(filter, 0, out int count, out IntPtr credentialsPtr))
+		{
+			int err = Marshal.GetLastWin32Error();
+			if (err == NativeMethods.ERROR_NOT_FOUND)
+			{
+				return [];
+			}
+			throw new CredentialStoreException("CredEnumerate failed.", new Win32Exception(err));
+		}
+
+		try
+		{
+			List<PersonaGUID> keys = new(count);
+			int ptrSize = Marshal.SizeOf<IntPtr>();
+			string prefix = $"{_servicePrefix}:";
+
+			for (int i = 0; i < count; i++)
+			{
+				IntPtr credPtr = Marshal.ReadIntPtr(credentialsPtr, i * ptrSize);
+				NativeMethods.CREDENTIAL native = Marshal.PtrToStructure<NativeMethods.CREDENTIAL>(credPtr);
+				string? target = native.TargetName;
+				if (target is null || !target.StartsWith(prefix, StringComparison.Ordinal))
+				{
+					continue;
+				}
+				string personaText = target[prefix.Length..];
+				keys.Add(SemanticString<PersonaGUID>.Create(personaText));
+			}
+			return keys;
+		}
+		finally
+		{
+			NativeMethods.CredFree(credentialsPtr);
+		}
+	}
+
+	private static class NativeMethods
+	{
+		internal const int CRED_TYPE_GENERIC = 1;
+		internal const int CRED_PERSIST_LOCAL_MACHINE = 2;
+		internal const int ERROR_NOT_FOUND = 1168;
+		internal const int CRED_MAX_CREDENTIAL_BLOB_SIZE = 5 * 512;
+
+		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+		internal struct CREDENTIAL
+		{
+			public int Flags;
+			public int Type;
+			[MarshalAs(UnmanagedType.LPWStr)] public string TargetName;
+			[MarshalAs(UnmanagedType.LPWStr)] public string? Comment;
+			public long LastWritten;
+			public int CredentialBlobSize;
+			public IntPtr CredentialBlob;
+			public int Persist;
+			public int AttributeCount;
+			public IntPtr Attributes;
+			[MarshalAs(UnmanagedType.LPWStr)] public string? TargetAlias;
+			[MarshalAs(UnmanagedType.LPWStr)] public string? UserName;
+		}
+
+		[DllImport("advapi32.dll", EntryPoint = "CredReadW", CharSet = CharSet.Unicode, SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static extern bool CredRead(string target, int type, int reservedFlag, out IntPtr credentialPtr);
+
+		[DllImport("advapi32.dll", EntryPoint = "CredWriteW", CharSet = CharSet.Unicode, SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static extern bool CredWrite([In] ref CREDENTIAL credential, [In] uint flags);
+
+		[DllImport("advapi32.dll", EntryPoint = "CredDeleteW", CharSet = CharSet.Unicode, SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static extern bool CredDelete(string target, int type, int reservedFlag);
+
+		[DllImport("advapi32.dll", EntryPoint = "CredEnumerateW", CharSet = CharSet.Unicode, SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		internal static extern bool CredEnumerate(string? filter, int flag, out int count, out IntPtr credentialsPtr);
+
+		[DllImport("advapi32.dll")]
+		internal static extern void CredFree([In] IntPtr cred);
+	}
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="ktsu.StrongStrings" Version="1.4.2" />
     <PackageVersion Include="ktsu.TextFilter" Version="1.5.3" />
     <PackageVersion Include="ktsu.ToStringJsonConverter" Version="1.2.4" />
-    <PackageVersion Include="ktsu.RoundTripStringJsonConverter" Version="1.0.1" />
+    <PackageVersion Include="ktsu.RoundTripStringJsonConverter" Version="1.0.10" />
     <PackageVersion Include="MessagePack" Version="3.1.4" />
     <PackageVersion Include="Microsoft.Build" Version="17.14.8" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.14.8" />

--- a/README.md
+++ b/README.md
@@ -1,180 +1,119 @@
 # ktsu.CredentialCache
 
-> A secure credential storage and management system for .NET applications.
+> A cross-platform credential cache for .NET that stores secrets in the host's native keyring.
 
 [![License](https://img.shields.io/github/license/ktsu-dev/CredentialCache)](https://github.com/ktsu-dev/CredentialCache/blob/main/LICENSE.md)
 [![NuGet](https://img.shields.io/nuget/v/ktsu.CredentialCache.svg)](https://www.nuget.org/packages/ktsu.CredentialCache/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/ktsu.CredentialCache.svg)](https://www.nuget.org/packages/ktsu.CredentialCache/)
 [![Build Status](https://github.com/ktsu-dev/CredentialCache/workflows/build/badge.svg)](https://github.com/ktsu-dev/CredentialCache/actions)
-[![GitHub Stars](https://img.shields.io/github/stars/ktsu-dev/CredentialCache?style=social)](https://github.com/ktsu-dev/CredentialCache/stargazers)
 
-## Introduction
+## Overview
 
-CredentialCache is a .NET library that provides a secure and convenient way to store, retrieve, and manage credentials in applications. It offers a flexible caching mechanism for various credential types while handling encryption, security, and persistence automatically.
+CredentialCache keeps credentials in memory for fast lookup during the lifetime of a process and persists each one through an `ICredentialStore` whose default implementation delegates to the platform-native secret manager:
 
-## Features
+| Platform | Backing store | API |
+|----------|--------------|-----|
+| Windows  | Windows Credential Manager | `advapi32` (`CredRead`/`CredWrite`/`CredDelete`) |
+| macOS    | Keychain Services | `Security.framework` (`SecKeychain*`) |
+| Linux    | freedesktop.org Secret Service | `libsecret-1.so.0` |
+| Other / opt-out | None | `InMemoryCredentialStore` |
 
-- **Secure Storage**: Encrypts sensitive credentials using platform-specific security features
-- **Memory Caching**: Efficiently caches credentials in memory for quick access
-- **Multiple Credential Types**: Supports usernames/passwords, API keys, tokens, and certificates
-- **Automatic Expiration**: Time-based expiration for cached credentials
-- **Credential Rotation**: Support for credential rotation and refresh workflows
-- **Thread Safety**: Safe for concurrent access from multiple threads
-- **Extensible**: Easily extend with custom credential types and storage providers
+Each persona's credential is stored as its own entry in the OS keyring &mdash; the library never writes a plaintext blob to disk.
 
 ## Installation
-
-### Package Manager Console
-
-```powershell
-Install-Package ktsu.CredentialCache
-```
-
-### .NET CLI
 
 ```bash
 dotnet add package ktsu.CredentialCache
 ```
 
-### Package Reference
-
-```xml
-<PackageReference Include="ktsu.CredentialCache" Version="x.y.z" />
-```
-
-## Usage Examples
-
-### Basic Example
+## Quick start
 
 ```csharp
 using ktsu.CredentialCache;
+using ktsu.CredentialCache.Storage;
 
-// Create a credential cache
-var cache = new CredentialCache();
+// Pick the platform-native store explicitly...
+ICredentialStore store = CredentialStoreFactory.CreateDefault();
+using CredentialCache cache = new(store);
 
-// Store a credential
-var credential = new UsernamePasswordCredential
+// ...or just use the singleton, which calls CreateDefault() on first access.
+CredentialCache singleton = CredentialCache.Instance;
+
+PersonaGUID persona = CredentialCache.CreatePersonaGUID();
+
+cache.AddOrReplace(persona, new CredentialWithUsernamePassword
 {
-    Username = "user@example.com",
-    Password = "securePassword123",
-    Domain = "example.com"
-};
+    Username = ktsu.Semantics.Strings.SemanticString<CredentialUsername>.Create("alice"),
+    Password = ktsu.Semantics.Strings.SemanticString<CredentialPassword>.Create("hunter2"),
+});
 
-cache.Store("myAppLogin", credential);
-
-// Retrieve the credential later
-if (cache.TryGet("myAppLogin", out UsernamePasswordCredential retrievedCredential))
+if (cache.TryGet(persona, out Credential? stored)
+    && stored is CredentialWithUsernamePassword creds)
 {
-    Console.WriteLine($"Retrieved username: {retrievedCredential.Username}");
-    // Use the credential for authentication
+    Console.WriteLine($"Hello, {creds.Username}");
 }
+
+cache.Remove(persona);
 ```
 
-### Working with API Credentials
+## Credential types
+
+- `CredentialWithNothing` &mdash; sentinel for "no credential required".
+- `CredentialWithToken` &mdash; opaque bearer / API token.
+- `CredentialWithUsernamePassword` &mdash; classic username + password pair.
+
+New credential types must derive from `Credential` and be registered with a `[JsonDerivedType]` attribute on `Credential` so polymorphic serialization round-trips through the keyring entry.
+
+## Customising the backing store
+
+`ICredentialStore` is a small CRUD interface (`TryLoad`/`Save`/`Remove`/`EnumerateKeys`). Bring your own implementation when you need a different backend (HashiCorp Vault, an encrypted file, a test double):
 
 ```csharp
-// Store an API key
-var apiCredential = new ApiKeyCredential
-{
-    Key = "api_12345abcde",
-    Secret = "apisecret_xyz789",
-    Endpoint = "https://api.example.com"
-};
-
-// Store with expiration
-cache.Store("apiAccess", apiCredential, TimeSpan.FromHours(1));
-
-// Check if credential exists and is not expired
-if (cache.Contains("apiAccess"))
-{
-    var cred = cache.Get<ApiKeyCredential>("apiAccess");
-    // Use the API credential
-}
+ICredentialStore store = new MyCustomStore();
+CredentialCache.ConfigureStore(store); // must be called before first Instance access
 ```
 
-### Advanced Usage with Persistent Storage
+For unit tests, use the in-memory store and skip the singleton entirely:
 
 ```csharp
-// Create a cache with persistent storage
-var options = new CredentialCacheOptions
-{
-    PersistToStorage = true,
-    StoragePath = "credentials.dat",
-    EncryptionLevel = EncryptionLevel.High
-};
-
-var persistentCache = new CredentialCache(options);
-
-// Store a credential that will be saved to disk
-var oauthCredential = new OAuthCredential
-{
-    AccessToken = "access_token_123",
-    RefreshToken = "refresh_token_456",
-    ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
-};
-
-persistentCache.Store("oauth", oauthCredential);
-
-// Later, even after application restart:
-var loadedCache = new CredentialCache(options);
-if (loadedCache.TryGet("oauth", out OAuthCredential oauth))
-{
-    if (oauth.IsExpired)
-    {
-        // Refresh the token
-        oauth = RefreshOAuthToken(oauth);
-        loadedCache.Store("oauth", oauth);
-    }
-    
-    // Use the OAuth token
-}
+using CredentialCache cache = new(new InMemoryCredentialStore());
 ```
 
-## API Reference
+## Platform notes
 
-### `CredentialCache` Class
+- **Windows Credential Manager** caps the credential blob at 2560 bytes. Tokens larger than that will throw `CredentialStoreException` &mdash; split or compress before storing.
+- **Linux** requires `libsecret-1` (e.g. `apt install libsecret-1-0`) plus a running Secret Service implementation (gnome-keyring, KWallet's secret-service bridge, KeePassXC, &hellip;). Headless CI agents typically have neither &mdash; use `InMemoryCredentialStore` there.
+- **macOS** uses the user's default login keychain. The first access from an application prompts the user for permission, as with any keychain client.
+- `EnumerateKeys()` is fully implemented on Windows. On macOS and Linux it currently returns an empty sequence (implementing it would require substantially more native marshalling for a use-case most consumers can satisfy by tracking persona GUIDs themselves).
 
-The main class for storing and retrieving credentials.
+## API summary
 
-#### Properties
+### `CredentialCache`
 
-| Name | Type | Description |
-|------|------|-------------|
-| `Count` | `int` | Number of credentials in the cache |
-| `Options` | `CredentialCacheOptions` | Configuration options for this cache instance |
+| Member | Description |
+|--------|-------------|
+| `CredentialCache(ICredentialStore store)` | Construct an instance with an explicit store. |
+| `static Instance` | Process-wide singleton (lazy, thread-safe). |
+| `static ConfigureStore(ICredentialStore)` | Override the singleton's store. Must precede first `Instance` access. |
+| `static ResetSingletonForTesting()` | Dispose the singleton and clear configuration. Tests only. |
+| `static CreatePersonaGUID()` | Allocates a new `PersonaGUID`. |
+| `TryGet(persona, out cred)` | Memory-cache lookup with fallthrough to the backing store. |
+| `AddOrReplace(persona, cred)` | Persists eagerly through the store. |
+| `Remove(persona)` | Deletes from both the in-memory cache and the store. |
+| `RegisterCredentialFactory<T>(factory)` | Optional factory hook used by `TryCreate<T>`. |
+| `TryCreate<T>(out cred)` | Constructs a credential via a registered factory. |
+| `Dispose()` | Releases in-memory state. The OS store is left untouched. |
 
-#### Methods
+### `ICredentialStore`
 
-| Name | Return Type | Description |
-|------|-------------|-------------|
-| `Store(string key, ICredential credential, TimeSpan? expiration = null)` | `void` | Stores a credential with optional expiration |
-| `Get<T>(string key) where T : ICredential` | `T` | Gets a credential by key (throws if not found) |
-| `TryGet<T>(string key, out T credential) where T : ICredential` | `bool` | Tries to get a credential by key |
-| `Remove(string key)` | `bool` | Removes a credential from the cache |
-| `Contains(string key)` | `bool` | Checks if a credential exists and is not expired |
-| `Clear()` | `void` | Removes all credentials from the cache |
-
-### Credential Types
-
-| Type | Description |
-|------|-------------|
-| `UsernamePasswordCredential` | Standard username and password combination |
-| `ApiKeyCredential` | API key and optional secret |
-| `OAuthCredential` | OAuth access and refresh tokens |
-| `CertificateCredential` | Certificate-based authentication |
-
-## Contributing
-
-Contributions are welcome! Here's how you can help:
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-Please ensure your code follows security best practices when dealing with sensitive credential information.
+| Member | Description |
+|--------|-------------|
+| `Name` | Diagnostic identifier (`"Windows Credential Manager"`, `"macOS Keychain"`, `"Linux libsecret (Secret Service)"`, `"InMemory"`). |
+| `TryLoad(persona, out cred)` | Load a single credential. |
+| `Save(persona, cred)` | Persist or overwrite a single credential. |
+| `Remove(persona)` | Delete a single credential. |
+| `EnumerateKeys()` | Enumerate persona keys (Windows only by default). |
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.
+MIT &mdash; see [LICENSE.md](LICENSE.md).


### PR DESCRIPTION
## Audit findings

This branch is the result of an audit-and-finish pass on the library. The headline issues found on `main`:

1. **README lied about security.** It claimed the cache "encrypts sensitive credentials using platform-specific security features" — the actual implementation serialised credentials as **plaintext JSON** to `%APPDATA%/ktsu/CredentialCache` via `ktsu.PersistenceProvider`. There was no encryption anywhere.
2. **Couldn't restore.** `CredentialCache.csproj` inherited `TargetFrameworks=net5..10;netstandard2.0;netstandard2.1` from `ktsu.Sdk` but every upstream `ktsu.*Provider` dep only ships `net9.0`/`net10.0`. `dotnet restore` failed on every non-net9/10 TFM.
3. **Upstream namespaces had drifted.** `ktsu.UniversalSerializer.Json.JsonSerializer` had moved to `ktsu.UniversalSerializer.Services.Json.JsonSerializer`; `FileSystemProvider`'s ctor now requires options. The library no longer even compiled against the pinned packages.
4. **README documented an API that doesn't exist.** `UsernamePasswordCredential`, `ApiKeyCredential`, `OAuthCredential`, `CertificateCredential`, `CredentialCacheOptions`, `Store/Get/TryGet/Contains/Remove/Clear`, expiration — none of it was real. The real surface is a `CredentialCache.Instance` singleton over `PersonaGUID` keys.
5. **Tests polluted user state.** With no isolation hook, tests ran against the singleton's default disk provider and accumulated credentials in the real user AppData on every run.
6. **CI was Windows-only.** Despite shipping as a cross-platform library, `runs-on: windows-latest` was the only matrix entry.

## What's in this PR

### New persistence layer (`Storage/`)

| Platform | Implementation | API |
|----------|----------------|-----|
| Windows  | `WindowsCredentialStore` | `advapi32.dll` &mdash; `CredReadW` / `CredWriteW` / `CredDeleteW` / `CredEnumerateW` |
| macOS    | `MacOsCredentialStore` | `Security.framework` &mdash; `SecKeychainAddGenericPassword` / `Find` / `ModifyAttributesAndData` / `Delete` |
| Linux    | `LinuxSecretServiceCredentialStore` | `libsecret-1.so.0` &mdash; `secret_password_store_sync` / `lookup_sync` / `clear_sync` |
| _opt-out_ | `InMemoryCredentialStore` | for tests and headless CI agents |

Each `PersonaGUID` becomes its own entry in the OS keyring (service-scoped). `CredentialStoreFactory.CreateDefault()` picks the right one for the current `RuntimeInformation.IsOSPlatform(...)` and throws `PlatformNotSupportedException` otherwise. `CredentialStoreException` wraps native failures with the underlying `Win32Exception`/status code.

### `CredentialCache` refactor

- New public constructor `CredentialCache(ICredentialStore)` for DI and tests.
- Kept the `Instance` singleton (lazy + thread-safe) for back-compat, but it now resolves its store via `CredentialStoreFactory.CreateDefault()` instead of hard-wiring the broken `AppDataPersistenceProvider`.
- Added `Remove(PersonaGUID)`, `Dispose()` that doesn't double-flush, and `ResetSingletonForTesting()` so tests stop polluting user AppData.
- Renamed `ConfigurePersistenceProvider` → `ConfigureStore` to match the new abstraction.
- `TryGet` now falls through to the backing store on a miss, populating the in-memory cache.

### Serialization

- Dropped `ktsu.AppDataStorage` / `ktsu.FileSystemProvider` / `ktsu.PersistenceProvider` / `ktsu.UniversalSerializer` (broken upstream surface).
- New public `CredentialSerialization` helper using `System.Text.Json` + `[JsonPolymorphic]` directly.
- Wired in `ktsu.RoundTripStringJsonConverterFactory` so `SemanticString<T>` values (`CredentialToken`, `CredentialUsername`, `CredentialPassword`, `PersonaGUID`) round-trip as JSON strings &mdash; without it, STJ treats them as `IEnumerable<char>` and explodes on deserialize.

### Project & CI

- Constrained `TargetFrameworks` to `net9.0;net10.0` (the only TFMs the remaining deps actually publish for).
- New `.github/workflows/cross-platform.yml`: build + test matrix on `ubuntu-latest` / `windows-latest` / `macos-latest` with `libsecret-1-0` installed on Linux. The existing publish-oriented `dotnet.yml` is untouched.
- Test project sets `UseAppHost=false` so distro-specific `Microsoft.NETCore.App.Host.{rid}` packages aren't required at restore time.

### Tests

- Every test now constructs its own `CredentialCache` over a fresh `InMemoryCredentialStore` &mdash; no shared singleton, no disk writes.
- Migrated `Assert.ThrowsException<>` → `Assert.Throws<>` for MSTest 4.x.
- Added: backing-store round-trip, `Remove` across both layers, `Dispose` semantics, null-store guard, singleton store-injection behaviour, and a polymorphic JSON round-trip for every `Credential` subclass.
- All 17 tests pass locally on Linux.

## Platform caveats (also documented in README)

- Windows Credential Manager caps the credential blob at 2560 bytes; oversized credentials throw `CredentialStoreException`.
- Linux needs `libsecret-1` installed **and** a running Secret Service (gnome-keyring / KWallet bridge / KeePassXC / &hellip;). Headless CI agents typically have neither &mdash; use `InMemoryCredentialStore`.
- macOS uses the default login keychain and will prompt the user the first time the app accesses it.
- `EnumerateKeys()` is fully implemented on Windows. macOS/Linux currently return an empty sequence (the modern `SecItemCopyMatching` / `secret_search_sync` paths need substantial CoreFoundation / GLib marshalling for a use case most consumers can serve by tracking persona GUIDs themselves).

## Test plan

- [x] `dotnet build CredentialCache.sln` &mdash; clean on `net9.0` + `net10.0` (3 SourceLink warnings only).
- [x] `dotnet test` on Linux &mdash; 17/17 pass.
- [ ] CI matrix run against Linux / macOS / Windows runners.
- [ ] Manual smoke test that `WindowsCredentialStore` writes into the real Credential Manager (cannot exercise from CI sandbox).
- [ ] Manual smoke test of `MacOsCredentialStore` against the login keychain.
- [ ] Manual smoke test of `LinuxSecretServiceCredentialStore` against `gnome-keyring` or equivalent.

https://claude.ai/code/session_017B9mN9F7C3pWGZRyoKBd6R

---
_Generated by [Claude Code](https://claude.ai/code/session_017B9mN9F7C3pWGZRyoKBd6R)_